### PR TITLE
bumped bjeavons/zxcvbn-php package version to support php8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "sort-packages": true
   },
   "require": {
-    "bjeavons/zxcvbn-php": "1.2.*"
+    "bjeavons/zxcvbn-php": "^1.3"
   },
   "autoload": {
     "files": [


### PR DESCRIPTION
zxcvbn-php library in required version 1.2.* does not support php8:

`[2023-05-29T07:18:26.295246+00:00] report.CRITICAL: Exception: Deprecated Functionality: preg_split(): Passing null to parameter #3 ($limit) of type int is deprecated in /srv/magento/woodies-stage2/deploys/0.0.0.10/vendor/bjeavons/zxcvbn-php/src/Matchers/L33tMatch.php on line 138 in /srv/magento/woodies-stage2/deploys/0.0.0.10/vendor/magento/framework/App/ErrorHandler.php:62
Stack trace:
#0 [internal function]: Magento\Framework\App\ErrorHandler->handler(8192, 'preg_split(): P...', '/srv/magento/wo...', 138)
#1 /srv/magento/woodies-stage2/deploys/0.0.0.10/vendor/bjeavons/zxcvbn-php/src/Matchers/L33tMatch.php(138): preg_split('//u', 'ttm3CbC8*Mtg7G7...', NULL, 1)
#2 /srv/magento/woodies-stage2/deploys/0.0.0.10/vendor/bjeavons/zxcvbn-php/src/Matchers/L33tMatch.php(34): ZxcvbnPhp\Matchers\L33tMatch::getL33tSubtable('ttm3CbC8*Mtg7G7...')
#3 /srv/magento/woodies-stage2/deploys/0.0.0.10/vendor/bjeavons/zxcvbn-php/src/Matcher.php(39): ZxcvbnPhp\Matchers\L33tMatch::match('ttm3CbC8*Mtg7G7...', Array)
#4 /srv/magento/woodies-stage2/deploys/0.0.0.10/vendor/bjeavons/zxcvbn-php/src/Zxcvbn.php(73): ZxcvbnPhp\Matcher->getMatches('ttm3CbC8*Mtg7G7...', Array)
#5 /srv/magento/woodies-stage2/deploys/0.0.0.10/vendor/wearejh/m2-module-password-policy/Model/PasswordRepository.php(34): ZxcvbnPhp\Zxcvbn->passwordStrength('ttm3CbC8*Mtg7G7...')
#6 /srv/magento/woodies-stage2/deploys/0.0.0.10/vendor/wearejh/m2-module-password-policy/Validator/Password.php(41): Jh\PasswordPolicy\Model\PasswordRepository->get('ttm3CbC8*Mtg7G7...')
#7 /srv/magento/woodies-stage2/deploys/0.0.0.10/vendor/wearejh/m2-module-password-policy/Plugin/CheckPasswordStrengthPlugin.php(37): Jh\PasswordPolicy\Validator\Password->validate('ttm3CbC8*Mtg7G7...')
#8 /srv/magento/woodies-stage2/deploys/0.0.0.10/vendor/magento/framework/Interception/Interceptor.php(121): Jh\PasswordPolicy\Plugin\CheckPasswordStrengthPlugin->beforeCreateAccount(Object(Magento\Customer\Model\AccountManagementApi\Interceptor), Object(Magento\Customer\Model\Data\Customer), 'ttm3CbC8*Mtg7G7...', '')
#9 /srv/magento/woodies-stage2/deploys/0.0.0.10/vendor/magento/framework/Interception/Interceptor.php(153): Magento\Customer\Model\AccountManagementApi\Interceptor->Magento\Framework\Interception\{closure}(Object(Magento\Customer\Model\Data\Customer), 'ttm3CbC8*Mtg7G7...', '')
#10 /srv/magento/woodies-stage2/deploys/0.0.0.10/generated/code/Magento/Customer/Model/AccountManagementApi/Interceptor.php(23): Magento\Customer\Model\AccountManagementApi\Interceptor->___callPlugins('createAccount', Array, Array)`

Bumped to 1.3 which has compatibility fixes introduced: https://github.com/bjeavons/zxcvbn-php/releases